### PR TITLE
Fix/android 15 edge to edge

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,11 +42,5 @@ dependencies {
     testImplementation libs.junit
     androidTestImplementation libs.ext.junit
     androidTestImplementation libs.espresso.core
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.11.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     implementation 'androidx.core:core:1.12.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace 'com.eink.screendrawing'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId "com.eink.screendrawing"
@@ -42,5 +42,5 @@ dependencies {
     testImplementation libs.junit
     androidTestImplementation libs.ext.junit
     androidTestImplementation libs.espresso.core
-    implementation 'androidx.core:core:1.12.0'
+    implementation 'androidx.core:core:1.15.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,9 +9,9 @@ android {
     defaultConfig {
         applicationId "com.eink.screendrawing"
         minSdk 26
-        targetSdk 35
-        versionCode 10
-        versionName "1.1.9"
+        targetSdk 36
+        versionCode 11
+        versionName "1.1.10"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/eink/screendrawing/MainActivity.java
+++ b/app/src/main/java/com/eink/screendrawing/MainActivity.java
@@ -7,10 +7,12 @@ import android.provider.Settings;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.activity.EdgeToEdge;
 
 public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        EdgeToEdge.enable(this);
         super.onCreate(savedInstanceState);
         
         if (!Settings.canDrawOverlays(this)) {

--- a/app/src/main/java/com/eink/screendrawing/OverlayService.java
+++ b/app/src/main/java/com/eink/screendrawing/OverlayService.java
@@ -17,6 +17,9 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 
 import androidx.core.content.ContextCompat;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 // Your custom view imports
 import com.eink.screendrawing.DrawingView;
@@ -90,6 +93,25 @@ public class OverlayService extends Service {
         menuParams.y = 0;
 
         windowManager.addView(menuView, menuParams);
+
+        // 处理状态栏避让：将系统栏高度应用为菜单顶部内边距
+        // 这样即使菜单窗口在 y=0 处，交互区域（手柄）也会避开系统状态栏的触摸拦截区
+        int initialPaddingTop = menuView.getPaddingTop();
+        int initialPaddingBottom = menuView.getPaddingBottom();
+        int initialPaddingLeft = menuView.getPaddingLeft();
+        int initialPaddingRight = menuView.getPaddingRight();
+
+        ViewCompat.setOnApplyWindowInsetsListener(menuView, (v, insets) -> {
+            Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(
+                initialPaddingLeft + systemBars.left,
+                initialPaddingTop + systemBars.top,
+                initialPaddingRight + systemBars.right,
+                initialPaddingBottom + systemBars.bottom
+            );
+            return insets;
+        });
+
         setupMenuButtons(menuParams);
     }
 

--- a/app/src/main/java/com/eink/screendrawing/OverlayService.java
+++ b/app/src/main/java/com/eink/screendrawing/OverlayService.java
@@ -101,6 +101,8 @@ public class OverlayService extends Service {
         int initialPaddingLeft = menuView.getPaddingLeft();
         int initialPaddingRight = menuView.getPaddingRight();
 
+        // 处理状态栏避让：将系统栏高度应用为菜单顶部内边距
+        // 只要菜单不超出屏幕边缘，Insets 就会保持稳定
         ViewCompat.setOnApplyWindowInsetsListener(menuView, (v, insets) -> {
             Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
             v.setPadding(
@@ -167,6 +169,21 @@ public class OverlayService extends Service {
         final float[] initialTouchX = new float[1];
         final float[] initialTouchY = new float[1];
 
+        // 获取屏幕尺寸用于边界限制
+        final int screenWidth;
+        final int screenHeight;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+            android.view.WindowMetrics windowMetrics = windowManager.getCurrentWindowMetrics();
+            android.graphics.Rect bounds = windowMetrics.getBounds();
+            screenWidth = bounds.width();
+            screenHeight = bounds.height();
+        } else {
+            android.util.DisplayMetrics displayMetrics = new android.util.DisplayMetrics();
+            windowManager.getDefaultDisplay().getRealMetrics(displayMetrics);
+            screenWidth = displayMetrics.widthPixels;
+            screenHeight = displayMetrics.heightPixels;
+        }
+
         dragHandle.setOnTouchListener(new View.OnTouchListener() {
             @Override
             public boolean onTouch(View v, MotionEvent event) {
@@ -191,8 +208,13 @@ public class OverlayService extends Service {
                     case MotionEvent.ACTION_MOVE:
                         // Only handle drag if it's not a double click
                         if (System.currentTimeMillis() - lastClickTime > 100) {
-                            menuParams.x = initialX[0] + (int) (event.getRawX() - initialTouchX[0]);
-                            menuParams.y = initialY[0] + (int) (event.getRawY() - initialTouchY[0]);
+                            int newX = initialX[0] + (int) (event.getRawX() - initialTouchX[0]);
+                            int newY = initialY[0] + (int) (event.getRawY() - initialTouchY[0]);
+
+                            // 限制在屏幕范围内，防止 Insets 因越界而失效
+                            menuParams.x = Math.max(0, Math.min(newX, screenWidth - menuView.getWidth()));
+                            menuParams.y = Math.max(0, Math.min(newY, screenHeight - menuView.getHeight()));
+
                             windowManager.updateViewLayout(menuView, menuParams);
                         }
                         return true;

--- a/app/src/main/java/com/eink/screendrawing/OverlayService.java
+++ b/app/src/main/java/com/eink/screendrawing/OverlayService.java
@@ -58,9 +58,14 @@ public class OverlayService extends Service {
                 WindowManager.LayoutParams.MATCH_PARENT,
                 WindowManager.LayoutParams.MATCH_PARENT,
                 WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
-                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE 
+                        | WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN 
+                        | WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
                 PixelFormat.TRANSLUCENT
         );
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            drawParams.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+        }
         windowManager.addView(drawingView, drawParams);
 
         // Initialize menu
@@ -72,9 +77,14 @@ public class OverlayService extends Service {
                 WindowManager.LayoutParams.WRAP_CONTENT,
                 WindowManager.LayoutParams.WRAP_CONTENT,
                 WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
-                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE 
+                        | WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN 
+                        | WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
                 PixelFormat.TRANSLUCENT
         );
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            menuParams.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+        }
         menuParams.gravity = Gravity.TOP | Gravity.LEFT;
         menuParams.x = 0;
         menuParams.y = 0;

--- a/app/src/main/res/layout/floating_menu.xml
+++ b/app/src/main/res/layout/floating_menu.xml
@@ -58,7 +58,7 @@
         android:id="@+id/btnUndo"
         android:layout_width="@dimen/menu_button_size"
         android:layout_height="@dimen/menu_button_size"
-        android:layout_marginTop="16dp"
+        android:layout_marginTop="@dimen/menu_button_margin_top"
         android:background="?attr/selectableItemBackgroundBorderless">
 
         <ImageView
@@ -92,8 +92,8 @@
         android:id="@+id/dividerView"
         android:layout_width="32dp"
         android:layout_height="1dp"
-        android:layout_marginTop="12dp"
-        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="4dp"
         android:background="#33FFFFFF" />
 
     <!-- 4. 退出 (电源) -->

--- a/app/src/main/res/layout/floating_menu.xml
+++ b/app/src/main/res/layout/floating_menu.xml
@@ -92,8 +92,8 @@
         android:id="@+id/dividerView"
         android:layout_width="32dp"
         android:layout_height="1dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="4dp"
+        android:layout_marginTop="6dp"
+        android:layout_marginBottom="2dp"
         android:background="#33FFFFFF" />
 
     <!-- 4. 退出 (电源) -->

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -4,7 +4,7 @@
     <dimen name="floating_menu_width">72dp</dimen>
     <dimen name="floating_menu_corner_radius">36dp</dimen>
     <dimen name="floating_menu_elevation">8dp</dimen>
-    <dimen name="floating_menu_padding_bottom">10dp</dimen>
+    <dimen name="floating_menu_padding_bottom">8dp</dimen>
 
     <!-- Drag Handle -->
     <dimen name="drag_handle_width">24dp</dimen>
@@ -14,7 +14,7 @@
 
     <!-- Menu Buttons -->
     <dimen name="menu_button_size">48dp</dimen>
-    <dimen name="menu_button_margin_top">4dp</dimen>
+    <dimen name="menu_button_margin_top">2dp</dimen>
     <dimen name="menu_icon_size">24dp</dimen>
 
     <!-- Active Brush Background -->

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -4,7 +4,7 @@
     <dimen name="floating_menu_width">72dp</dimen>
     <dimen name="floating_menu_corner_radius">36dp</dimen>
     <dimen name="floating_menu_elevation">8dp</dimen>
-    <dimen name="floating_menu_padding_bottom">16dp</dimen>
+    <dimen name="floating_menu_padding_bottom">10dp</dimen>
 
     <!-- Drag Handle -->
     <dimen name="drag_handle_width">24dp</dimen>
@@ -14,7 +14,7 @@
 
     <!-- Menu Buttons -->
     <dimen name="menu_button_size">48dp</dimen>
-    <dimen name="menu_button_margin_top">8dp</dimen>
+    <dimen name="menu_button_margin_top">4dp</dimen>
     <dimen name="menu_icon_size">24dp</dimen>
 
     <!-- Active Brush Background -->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
 appcompat = "1.6.1"
-material = "1.10.0"
+material = "1.13.0"
 activity = "1.8.0"
 constraintlayout = "2.1.4"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,9 @@ agp = "8.7.2"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
-appcompat = "1.6.1"
+appcompat = "1.7.0"
 material = "1.13.0"
-activity = "1.8.0"
+activity = "1.9.3"
 constraintlayout = "2.1.4"
 
 [libraries]


### PR DESCRIPTION
1. Updated Material library to 1.13.0 to fix deprecated Window API warnings. 
2. Added EdgeToEdge.enable(this) for Android 15 compatibility. 
3. Added FLAG_LAYOUT_IN_SCREEN and NO_LIMITS to OverlayService to allow floating menu to draw over status bar and cutouts.